### PR TITLE
Fix mode 2/3/4 trial execution in CommandExecutor

### DIFF
--- a/controller/PanelsController.m
+++ b/controller/PanelsController.m
@@ -845,6 +845,9 @@ classdef PanelsController < handle
             end                                    
         end
 
+        % DEPRECATED: Use trialParams() instead. startG41Trial has a
+        % parameter order bug (frameRate/posX swapped on the wire) and
+        % will be removed in a future release.
         function rtn = startG41Trial(self, mode, patID, posX, dur, frameRate, gain)
             arguments
                 self (1,1) PanelsController

--- a/experimentExecution/CommandExecutor.m
+++ b/experimentExecution/CommandExecutor.m
@@ -126,7 +126,7 @@ classdef CommandExecutor < handle
                                     dur = command.duration;
                                     frameRate = command.frame_rate;
 
-                                    self.arenaController.startG41Trial(mode, patID, posX, dur*10, frameRate);
+                                    self.arenaController.trialParams(2, patID, frameRate, posX, 0, dur*10, false);
                                     pause(dur);
                                     
         
@@ -140,7 +140,7 @@ classdef CommandExecutor < handle
                                     posX = command.frame_index;
                                     dur = command.duration;
 
-                                    self.arenaController.startG41Trial(mode, patID, posX, dur*10);
+                                    self.arenaController.trialParams(3, patID, 0, posX, 0, dur*10, false);
                                     pause(dur);
 
                                 case 4
@@ -151,10 +151,9 @@ classdef CommandExecutor < handle
                                     patID = command.pattern_ID;
                                     posX = command.frame_index;
                                     dur = command.duration;
-                                    frameRate = 1; %Not used but need filler to pass in to controller
-                                    gain = command.gain; 
+                                    gain = command.gain;
 
-                                    self.arenaController.startG41Trial(mode, patID, posX, dur*10, frameRate, gain);
+                                    self.arenaController.trialParams(4, patID, 0, posX, gain, dur*10, false);
                                     pause(dur);
                             end
                         else


### PR DESCRIPTION
## Summary
- Migrates CommandExecutor from `startG41Trial()` to `trialParams()` for all trial modes (2, 3, 4)
- `startG41Trial` has a parameter order bug — `frameRate` and `posX` are swapped on the wire vs the function signature
- `trialParams` is the validated implementation already used by all demo and test scripts
- Marks `startG41Trial` as deprecated in PanelsController.m

## Root Cause

`startG41Trial()` function signature: `(mode, patID, posX, dur, frameRate, gain)`
Wire encoding sends: `mode → patID → frameRate → posX → gain → dur`

This means callers' `posX` value ends up in the wrong wire position. The bug only affects YAML-driven experiments (via CommandExecutor), not manual testing (which uses `trialParams` directly).

## Changes

| Mode | Before (broken) | After (correct) |
|------|-----------------|-----------------|
| 2 | `startG41Trial(mode, patID, posX, dur*10, frameRate)` | `trialParams(2, patID, frameRate, posX, 0, dur*10, false)` |
| 3 | `startG41Trial(mode, patID, posX, dur*10)` | `trialParams(3, patID, 0, posX, 0, dur*10, false)` |
| 4 | `startG41Trial(mode, patID, posX, dur*10, frameRate, gain)` | `trialParams(4, patID, 0, posX, gain, dur*10, false)` |

## Test plan
- [x] `run_all_tests()` — 29/29 passed
- [x] `run_merge_gate_tests()` — 60/60 passed
- [ ] Hardware validation: run `test_mode3.m` + `checklist_g41_hardware.md` Part B on live G4.1 arena

🤖 Generated with [Claude Code](https://claude.com/claude-code)