### PR TITLE
docs(readme): fix stale G6 config names + add two missing entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ Standard arena configs are in `configs/arenas/`:
 
 | Config | Generation | Panels | Description |
 |--------|------------|--------|-------------|
-| G6_2x10_full | G6 | 2×10 | Full cylinder, 20 panels |
-| G6_2x8_walking | G6 | 2×8 | Walking arena, 16 panels |
+| G6_2x10 | G6 | 2×10 | Full G6 arena, 360° coverage, 20 panels |
+| G6_2x8of10 | G6 | 2×8 of 10 | Walking arena, columns 0 + 9 uninstalled (288° coverage), 16 panels |
+| G6_3x12of18 | G6 | 3×12 of 18 | Partial arena, 12 of 18 columns installed (240° coverage), 36 panels |
+| G6_3x16_full | G6 | 3×16 | Full arena, 360° coverage, 48 panels |
 | G41_2x12_cw | G4.1 | 2×12 | Clockwise, c0 at south |
 | G4_3x12_full | G4 | 3×12 | 3-row full arena |
 | G4_4x12_full | G4 | 4×12 | 4-row full arena |


### PR DESCRIPTION
## Summary

The README's Config table listed `G6_2x10_full` and `G6_2x8_walking`, which don't match any registered config in `configs/arena_registry/`. The registered names per `configs/arena_registry/index.yaml` are:

| Was (stale) | Correct (registered) |
|---|---|
| `G6_2x10_full` | `G6_2x10` |
| `G6_2x8_walking` | `G6_2x8of10` |

Also adds two G6 configs that were registered (in `configs/arenas/`) but missing from the README:
- `G6_3x12of18` — 3 rows, 12 of 18 columns installed (240° coverage), 36 panels
- `G6_3x16_full` — 3 rows, 16 columns, 360° coverage, 48 panels

Descriptions pulled directly from each arena's YAML `description:` field. Diff is 4 inserted / 2 deleted lines, table-only.

Flagged as an out-of-band item from [`Modular-LED-Display/docs/development/g6_docs-open-issues.md`](https://github.com/reiserlab/Modular-LED-Display/blob/main/docs/development/g6_docs-open-issues.md) § Deferred design pressure.

## Test plan

- [x] Diff inspected; only the Config table touched
- [x] All four new/fixed names verified against `configs/arena_registry/index.yaml` G6 namespace (arena IDs 1, 2, 3, … — `G6_2x10`, `G6_2x8of10`, `G6_3x12of18`, `G6_3x16_full` all present)
- [x] Descriptions verified against each `configs/arenas/G6_*.yaml`'s `description:` field